### PR TITLE
Fix NUN (Nuneaton and Bedworth) scraper

### DIFF
--- a/scrapers/NUN-nuneaton-and-bedworth/councillors.py
+++ b/scrapers/NUN-nuneaton-and-bedworth/councillors.py
@@ -5,6 +5,7 @@ from lgsf.councillors.scrapers import HTMLCouncillorScraper
 
 
 class Scraper(HTMLCouncillorScraper):
+    http_lib = "requests"
     list_page = {
         "container_css_selector": "ul.list--listing",
         "councillor_css_selector": "article.listing",
@@ -21,7 +22,7 @@ class Scraper(HTMLCouncillorScraper):
         )
 
         ward = (
-            soup.find("strong", text=re.compile("Ward:"))
+            soup.find("strong", string=re.compile("Ward:"))
             .find_parent("p")
             .get_text(strip=True)
             .replace("Ward:", "")
@@ -29,7 +30,7 @@ class Scraper(HTMLCouncillorScraper):
         )
 
         party = (
-            soup.find("strong", text=re.compile("Party:"))
+            soup.find("strong", string=re.compile("Party:"))
             .find_parent("p")
             .get_text(strip=True)
             .replace("Party:", "")

--- a/scrapers/NUN-nuneaton-and-bedworth/councillors.py
+++ b/scrapers/NUN-nuneaton-and-bedworth/councillors.py
@@ -43,9 +43,9 @@ class Scraper(HTMLCouncillorScraper):
             party=party,
             division=ward,
         )
-        councillor.email = soup.select_one("a[href^=mailto]")["href"].replace(
-            "mailto:", ""
-        )
+        email_link = soup.select_one("a[href^=mailto]")
+        if email_link:
+            councillor.email = email_link["href"].replace("mailto:", "")
         image = soup.select_one(".image--feature")
         if image:
             councillor.photo_url = urljoin(


### PR DESCRIPTION
## What broke

Two issues:

1. The `rnet` HTTP library (Rust/BoringSSL) rejects nuneatonandbedworth.gov.uk's certificate chain with `X509VerifyError: self signed certificate in certificate chain`.
2. `TypeError: 'NoneType' object is not subscriptable` — email extraction crashed for councillors without a mailto link.

## What was fixed

- Added `http_lib = "requests"` to bypass the rnet SSL rejection
- Guarded email extraction with a `None` check
- Updated deprecated `text=` keyword to `string=` in `soup.find()` calls

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 37 |
| With email address | 36 |
| With photo | 36 |

🤖 Automated fix