### PR TITLE
Fix RUG (Rugby) scraper: handle missing email span

### DIFF
--- a/scrapers/RUG-rugby/councillors.py
+++ b/scrapers/RUG-rugby/councillors.py
@@ -36,7 +36,9 @@ class Scraper(HTMLCouncillorScraper):
             party=party,
             division=ward,
         )
-        councillor.email = soup.find("span", text=re.compile("@")).get_text(strip=True)
+        email_span = soup.find("span", text=re.compile("@"))
+        if email_span:
+            councillor.email = email_span.get_text(strip=True)
 
         image = soup.select_one(".councillor-details img")
         if image:


### PR DESCRIPTION
## What broke
`AttributeError: 'NoneType' object has no attribute 'get_text'` — `soup.find("span", text=re.compile("@"))` returned `None` for councillors who have no email displayed on their detail page.

## What was fixed
Added a null check before calling `.get_text()`. Councillors without a listed email are now scraped successfully without crashing.

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kpso39UnQ8kitv8dW3Uahc)_