### PR TITLE
Fix CHL (Chelmsford) scraper: handle missing photo, remove debug print

### DIFF
--- a/scrapers/CHL-chelmsford/councillors.py
+++ b/scrapers/CHL-chelmsford/councillors.py
@@ -16,7 +16,6 @@ class Scraper(PagedHTMLCouncillorScraper):
     def get_single_councillor(self, councillor_html):
         if councillor_html.find_all("th"):
             raise SkipCouncillorException
-        print(councillor_html)
         url = urljoin(self.base_url, councillor_html.a["href"])
         soup = self.get_page(url)
         name = soup.h1.get_text(strip=True).replace("Councillor ", "")
@@ -36,7 +35,7 @@ class Scraper(PagedHTMLCouncillorScraper):
         email = soup.find("h2", text=re.compile("Email address"))
         if email:
             councillor.email = email.find_next("a")["href"]
-        councillor.photo_url = urljoin(
-            self.base_url, soup.select_one("picture img")["src"]
-        )
+        picture_img = soup.select_one("picture img")
+        if picture_img:
+            councillor.photo_url = urljoin(self.base_url, picture_img["src"])
         return councillor


### PR DESCRIPTION
## What broke
`TypeError: 'NoneType' object is not subscriptable` — `soup.select_one("picture img")` returned `None` for councillors who have no portrait photo on their page.

Additionally there was a stray `print(councillor_html)` debug statement that would have been generating noisy output in production.

## What was fixed
- Made photo extraction conditional on the element being present
- Removed the debug `print` statement

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kpso39UnQ8kitv8dW3Uahc)_