### PR TITLE
Fix ERW (East Renfrewshire) scraper: handle missing CloudFlare email obfuscation

### DIFF
--- a/scrapers/ERW-east-renfrewshire/councillors.py
+++ b/scrapers/ERW-east-renfrewshire/councillors.py
@@ -46,9 +46,13 @@ class Scraper(HTMLCouncillorScraper):
             party=party,
             division=ward,
         )
-        councillor.email = decode_cfemail(
-            soup.select_one("td a span.__cf_email__")["data-cfemail"]
-        )
+        cf_span = soup.select_one("td a span.__cf_email__")
+        if cf_span:
+            councillor.email = decode_cfemail(cf_span["data-cfemail"])
+        else:
+            email_link = soup.select_one("a[href^=mailto]")
+            if email_link:
+                councillor.email = email_link["href"].replace("mailto:", "")
         councillor.photo_url = urljoin(
             self.base_url,
             soup.select_one(".a-relimage img")["src"],


### PR DESCRIPTION
## What broke
`TypeError: 'NoneType' object is not subscriptable` — `soup.select_one("td a span.__cf_email__")` returned `None`, meaning CloudFlare's email obfuscation span is absent for some (or all) councillors.

## What was fixed
Made the CloudFlare decode attempt conditional. If the `.__cf_email__` span is absent, fall back to looking for a direct `a[href^=mailto]` link. If neither is present, the email is simply not set.

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kpso39UnQ8kitv8dW3Uahc)_