### PR TITLE
Fix BRY (Bromley) scraper

### DIFF
--- a/scrapers/BRY-bromley/councillors.py
+++ b/scrapers/BRY-bromley/councillors.py
@@ -5,6 +5,7 @@ from lgsf.councillors.scrapers import HTMLCouncillorScraper
 
 
 class Scraper(HTMLCouncillorScraper):
+    http_lib = "requests"
     list_page = {
         "container_css_selector": "div.mgContent",
         "councillor_css_selector": "li",


### PR DESCRIPTION
## What broke

The `rnet` HTTP library (Rust/BoringSSL) rejects cds.bromley.gov.uk's certificate chain with `X509VerifyError: self signed certificate in certificate chain`, causing `ConnectionError` on startup.

## What was fixed

Added `http_lib = "requests"` so the scraper uses Python requests instead of rnet. The existing HTML selectors (`div.mgContent` → `li`, `div.page-content h1`, `Party:`/`Ward:` paragraphs, `a[href^=mailto]`) all work correctly once the connection issue is resolved.

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 58 |
| With email address | 58 |
| With photo | 58 |

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEYxnVb1KSJdXSXHm3Xyib)_