### PR TITLE
Fix CHL (Chelmsford) scraper

### DIFF
--- a/scrapers/CHL-chelmsford/councillors.py
+++ b/scrapers/CHL-chelmsford/councillors.py
@@ -7,6 +7,7 @@ from lgsf.councillors.scrapers import PagedHTMLCouncillorScraper
 
 
 class Scraper(PagedHTMLCouncillorScraper):
+    http_lib = "requests"
     list_page = {
         "container_css_selector": "table.directories-table__table",
         "councillor_css_selector": "tr",
@@ -34,7 +35,10 @@ class Scraper(PagedHTMLCouncillorScraper):
         )
         email = soup.find("h2", text=re.compile("Email address"))
         if email:
-            councillor.email = email.find_next("a")["href"]
+            href = email.find_next("a")["href"]
+            email_val = href.replace("mailto:", "").replace("tel:", "")
+            if "@" in email_val:
+                councillor.email = email_val
         picture_img = soup.select_one("picture img")
         if picture_img:
             councillor.photo_url = urljoin(self.base_url, picture_img["src"])


### PR DESCRIPTION
## What broke

Two issues:

1. The `rnet` HTTP library (Rust/BoringSSL) rejects chelmsford.gov.uk's certificate chain with `X509VerifyError: self signed certificate in certificate chain`.
2. Two councillors on chelmsford.gov.uk have a bug in the site's HTML where email links use `tel:email@domain` instead of `mailto:email@domain`, causing their addresses to be stored with a `tel:` prefix.

## What was fixed

- Added `http_lib = "requests"` to bypass the rnet SSL rejection
- Fixed email extraction to strip both `tel:` and `mailto:` prefixes, and only accept the value if it contains `@` (so actual phone numbers like `tel:01245 605887` are ignored)

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 57 |
| With email address | 57 |
| With photo | 56 |

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEYxnVb1KSJdXSXHm3Xyib)_