### PR TITLE
Fix RUG (Rugby) scraper

### DIFF
--- a/scrapers/RUG-rugby/councillors.py
+++ b/scrapers/RUG-rugby/councillors.py
@@ -6,6 +6,7 @@ from lgsf.councillors.scrapers import HTMLCouncillorScraper
 
 
 class Scraper(HTMLCouncillorScraper):
+    http_lib = "requests"
     list_page = {
         "container_css_selector": ".card-page",
         "councillor_css_selector": "dd",


### PR DESCRIPTION
## What broke

The `rnet` HTTP library (Rust/BoringSSL) rejects rugby.gov.uk's certificate chain with `X509VerifyError: self signed certificate in certificate chain`, causing `ConnectionError` on startup.

## What was fixed

Added `http_lib = "requests"` so the scraper uses Python requests instead of rnet. The existing HTML selectors (`.card-page` → `dd`, `.councillor-details h3`, `div.ward`, `div.party`) all work correctly once the connection issue is resolved.

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 42 |
| With email address | 37 |
| With photo | 33 |

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEYxnVb1KSJdXSXHm3Xyib)_