### PR TITLE
Fix HAO (Harborough) scraper

### DIFF
--- a/scrapers/HAO-harborough/councillors.py
+++ b/scrapers/HAO-harborough/councillors.py
@@ -3,3 +3,10 @@ from lgsf.councillors.scrapers import CMISCouncillorScraper
 
 class Scraper(CMISCouncillorScraper):
     verify_requests = False
+
+    def get_party_name(self, list_page_html):
+        for img in reversed(list_page_html.find_all("img")):
+            title = img.get("title") or img.get("alt", "")
+            if title and "(logo)" in title:
+                return title.replace("(logo)", "").strip()
+        return "Unknown"

--- a/scrapers/HAO-harborough/councillors.py
+++ b/scrapers/HAO-harborough/councillors.py
@@ -1,8 +1,12 @@
+import contextlib
+from urllib.parse import urljoin
+
 from lgsf.councillors.scrapers import CMISCouncillorScraper
 
 
 class Scraper(CMISCouncillorScraper):
     verify_requests = False
+    http_lib = "requests"
 
     def get_party_name(self, list_page_html):
         for img in reversed(list_page_html.find_all("img")):
@@ -10,3 +14,16 @@ class Scraper(CMISCouncillorScraper):
             if title and "(logo)" in title:
                 return title.replace("(logo)", "").strip()
         return "Unknown"
+
+    def get_single_councillor(self, list_page_html):
+        councillor = super().get_single_councillor(list_page_html)
+        with contextlib.suppress(AttributeError, TypeError):
+            for img in list_page_html.find_all("img"):
+                title = img.get("title", "")
+                alt = img.get("alt", "")
+                if "(logo)" not in title and "(logo)" not in alt:
+                    src = img.get("src")
+                    if src:
+                        councillor.photo_url = urljoin(self.base_url, src)
+                        break
+        return councillor


### PR DESCRIPTION
## What broke

`KeyError: 'title'` in `CMISCouncillorScraper.get_party_name()`. The base implementation does `find_all("img")[-1]["title"]`, but one councillor (David Gair, Lutterworth East) has no party logo image — he left the Labour party on 14 April 2026 and currently has no party affiliation. His block contains only a photo image with no `title` attribute, causing the KeyError.

Additionally, photos were never being extracted for this council.

## What was fixed

- Overrode `get_party_name` to scan images in reverse looking for one whose `title` or `alt` attribute contains `"(logo)"`. Falls back to `"Unknown"` when no party logo image is present.
- Overrode `get_single_councillor` to extract the councillor thumbnail from the CMIS list page person block: iterates `img` tags, skips the party logo (identified by `"(logo)"` in title/alt), and uses the first remaining image as `photo_url`.
- Added `http_lib = "requests"` to bypass wreq's SSL rejection of the self-signed CMIS certificate (`verify_requests = False` was already set for the same reason).

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 34 |
| With email address | 31 |
| With photo | 34 |

🤖 Automated fix