### PR TITLE
Fix ASF (Ashford) scraper: switch to requests to bypass wreq SSL rejection

### DIFF
--- a/scrapers/ASF-ashford/councillors.py
+++ b/scrapers/ASF-ashford/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    http_lib = "requests"


### PR DESCRIPTION
## What broke

The ModGov API at `ashford.moderngov.co.uk` redirects HTTP to HTTPS (via Cloudflare). wreq's embedded BoringSSL does not trust the certificate chain on this redirect, causing a `CERTIFICATE_VERIFY_FAILED` error that results in 0 councillors being scraped.

## What was fixed

Added `http_lib = "requests"` to the scraper class. The `requests` library uses the system CA store (which trusts the relevant cert chain) and correctly follows the HTTP→HTTPS redirect to the ModGov XML API.

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 48 |
| With email address | 46 |
| With photo | 48 |

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjaRzXXuojCS5p7YwzbGRp)_