### PR TITLE
Fix AGY (Isle of Anglesey) scraper: switch to requests and update base_url to HTTPS

### DIFF
--- a/scrapers/AGY-isle-of-anglesey/councillors.py
+++ b/scrapers/AGY-isle-of-anglesey/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    http_lib = "requests"

--- a/scrapers/AGY-isle-of-anglesey/metadata.json
+++ b/scrapers/AGY-isle-of-anglesey/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://democracy.anglesey.gov.uk",
+            "base_url": "https://democracy.anglesey.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## What broke

The scraper used `http://democracy.anglesey.gov.uk` as the base URL. The HTTP endpoint redirects to HTTPS, and wreq's BoringSSL fails to verify the certificate chain, causing 0 councillors to be scraped.

## What was fixed

- Updated `base_url` in `metadata.json` from `http://` to `https://` (the HTTP endpoint only ever redirects)
- Added `http_lib = "requests"` so the requests library handles the HTTPS connection using the system CA store

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 35 |
| With email address | 35 |
| With photo | 35 |

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjaRzXXuojCS5p7YwzbGRp)_