### PR TITLE
Fix BAB (Babergh) scraper: switch to requests to bypass wreq SSL rejection

### DIFF
--- a/scrapers/BAB-babergh/councillors.py
+++ b/scrapers/BAB-babergh/councillors.py
@@ -3,6 +3,8 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
+    http_lib = "requests"
+
     def get_single_councillor(self, ward, councillor_xml):
         councillor = super().get_single_councillor(ward, councillor_xml)
         if hasattr(councillor, "email") and "babergh.gov.uk" in councillor.email:


### PR DESCRIPTION
## What broke

The ModGov API at `baberghmidsuffolk.moderngov.co.uk` redirects HTTP to HTTPS (via Cloudflare). wreq's BoringSSL cannot verify the certificate chain, causing 0 councillors to be scraped.

## What was fixed

Added `http_lib = "requests"` to the scraper class. The `requests` library uses the system CA store and correctly handles the HTTP→HTTPS redirect to retrieve the Babergh councillors XML.

Note: the scraper only keeps Babergh councillors (filtered by `babergh.gov.uk` email domain) from the shared Babergh/Mid-Suffolk ModernGov system.

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 32 |
| With email address | 32 |
| With photo | 32 |

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjaRzXXuojCS5p7YwzbGRp)_