### PR TITLE
Fix ABC (Armagh City, Banbridge and Craigavon) scraper: requests + pagination

### DIFF
--- a/scrapers/ABC-armagh-city-banbridge-and-craigavon/councillors.py
+++ b/scrapers/ABC-armagh-city-banbridge-and-craigavon/councillors.py
@@ -1,14 +1,23 @@
 import codecs
+import contextlib
 import re
 
-from lgsf.councillors.scrapers import HTMLCouncillorScraper
+from lgsf.councillors.scrapers import PagedHTMLCouncillorScraper
 
 
-class Scraper(HTMLCouncillorScraper):
+class Scraper(PagedHTMLCouncillorScraper):
+    http_lib = "requests"
     list_page = {
         "container_css_selector": ".td-main-content",
         "councillor_css_selector": ".council-wrap-inner",
     }
+
+    def get_next_link(self, soup):
+        with contextlib.suppress(Exception):
+            for a in soup.select(".page-nav a"):
+                if a.get_text(strip=True) == "Next Page":
+                    return a["href"]
+        return None
 
     def decode_email(self, councillor_html):
         borked_email = councillor_html.select_one("a.mailto-link")["data-enc-email"]


### PR DESCRIPTION
## What broke

The WordPress site at `armaghbanbridgecraigavon.gov.uk/councillors/` was inaccessible via wreq due to a `CERTIFICATE_VERIFY_FAILED` SSL error (wreq's BoringSSL does not trust the certificate chain). Additionally, the councillors page is paginated across 3 pages and only the first page (16 councillors) was being scraped.

## What was fixed

- Switched to `PagedHTMLCouncillorScraper` with `http_lib = "requests"` to bypass the SSL issue
- Added a `get_next_link()` override that follows the "Next Page" link in `.page-nav` across all 3 pages, retrieving all 41 councillors

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 41 |
| With email address | 41 |
| With photo | 41 |

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjaRzXXuojCS5p7YwzbGRp)_