### PR TITLE
Fix BEN (Brent) scraper: switch to requests to bypass wreq SSL rejection

### DIFF
--- a/scrapers/BEN-brent/councillors.py
+++ b/scrapers/BEN-brent/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    http_lib = "requests"


### PR DESCRIPTION
## What broke

The ModGov API at `democracy.brent.gov.uk` redirects HTTP to HTTPS. wreq's BoringSSL fails to verify the certificate chain, causing 0 councillors to be scraped.

## What was fixed

Added `http_lib = "requests"` to the scraper class. The `requests` library uses the system CA store and correctly follows the HTTP→HTTPS redirect to the ModGov XML API.

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 57 |
| With email address | 57 |
| With photo | 57 |

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjaRzXXuojCS5p7YwzbGRp)_