### PR TITLE
Fix PLY (Plymouth) scraper

### DIFF
--- a/scrapers/PLY-plymouth/councillors.py
+++ b/scrapers/PLY-plymouth/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False


### PR DESCRIPTION
## What broke

The ModGov instance at `democracy.plymouth.gov.uk` presents a TLS certificate that wreq's embedded BoringSSL rejects with `CERTIFICATE_VERIFY_FAILED`. The scraper had no `verify_requests` override, so wreq defaulted to strict certificate verification and the connection failed immediately (< 1 s).

Note: prior to commit `92a0b8d` (merged today), `verify_requests = False` was silently ignored by wreq due to a wrong kwarg name (`verify=` instead of `tls_verify=`). Now that the kwarg is fixed, this one-line change is sufficient.

## What was fixed

- Added `verify_requests = False` to `Scraper` class — passes `tls_verify=False, tls_verify_hostname=False` to the wreq client, bypassing certificate validation for this read-only public data source

## Scrape results

Local verification was not possible this run: the ModGov hosting provider returns 503 for requests originating from this environment's IP range. The fix follows the identical pattern applied to TEI and EDE earlier today (both now passing in the failing feed).

| Metric | Count |
|--------|-------|
| Councillors found | N/A — local run blocked by hosting IP |
| With email address | N/A |
| With photo | N/A |

🤖 Automated fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWFAAKZXsEhJKBg695hYHm)_