### PR TITLE
Fix HAR (Harlow): update ModGov base_url to harlow.moderngov.co.uk

### DIFF
--- a/scrapers/HAR-harlow/metadata.json
+++ b/scrapers/HAR-harlow/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://moderngov.harlow.gov.uk",
+            "base_url": "https://harlow.moderngov.co.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## Summary

- `moderngov.harlow.gov.uk` is DNS-dead (NXDomain)
- Harlow have migrated their ModGov to `harlow.moderngov.co.uk`
- Updated `base_url` in `metadata.json` — no scraper code change needed

## Test plan

- [x] Scraper returns 33 councillors with names, wards, parties, emails and photos

Fixes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)