### PR TITLE
Fix WYC (Wychavon): update ModGov base_url to include /modern.gov path

### DIFF
--- a/scrapers/WYC-wychavon/metadata.json
+++ b/scrapers/WYC-wychavon/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "https://mgov.wychavon.gov.uk",
+            "base_url": "https://mgov.wychavon.gov.uk/modern.gov",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## Summary

- The ModGov API at `https://mgov.wychavon.gov.uk` was returning 503
- The instance is still live but now lives at `https://mgov.wychavon.gov.uk/modern.gov/`
- Updated `base_url` in `metadata.json` — no scraper code change needed

## Test plan

- [x] Scraper returns 43 councillors with names, wards, parties, emails and photos

Fixes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)