### PR TITLE
Fix NEL (North East Lincolnshire): rewrite for new accordion page structure

### DIFF
--- a/scrapers/NEL-north-east-lincolnshire/councillors.py
+++ b/scrapers/NEL-north-east-lincolnshire/councillors.py
@@ -1,37 +1,97 @@
-import contextlib
 import re
 
-from lgsf.councillors.exceptions import SkipCouncillorException
 from lgsf.councillors.scrapers import HTMLCouncillorScraper
+
+SKIP_HEADINGS = {"Your Cabinet"}
+
+
+def decode_cfemail(hexstr: str) -> str:
+    data = bytes.fromhex(hexstr)
+    key = data[0]
+    return bytes(b ^ key for b in data[1:]).decode("utf-8")
 
 
 class Scraper(HTMLCouncillorScraper):
     list_page = {
-        "container_css_selector": "main .col-12 .page-content:nth-child(1)",
-        "councillor_css_selector": "li",
+        "container_css_selector": "main",
+        "councillor_css_selector": "h4",
     }
 
-    def get_single_councillor(self, councillor_html):
-        url = councillor_html.a["href"]
-        page = self.get_page(url)
-        soup = page.select(".wp-block-column")[0]
-        party_guess = soup.find_all("p")[1].get_text(strip=True)
-        title = soup.h2.get_text(strip=True)
-        if not title.startswith(party_guess):
-            raise SkipCouncillorException("Party doesn't match")
-        name = soup.p.get_text(strip=True)
-        party = party_guess
-        ward = soup.find("a", href=re.compile("ward")).get_text(strip=True)
-        councillor = self.add_councillor(
-            url, identifier=url, name=name, party=party, division=ward
-        )
-        with contextlib.suppress(AttributeError):
-            councillor.email = (
-                page.select(".wp-block-column")[1]
-                .find(lambda t: t.name == "p" and "Email" in t.text)
-                .a["href"]
-            ).replace("mailto:", "")
+    def get_councillors(self):
+        page = self.get_page(self.base_url)
+        results = []
 
-        if soup.img:
-            councillor.photo_url = soup.img["src"]
+        for h3 in page.select("main h3"):
+            ward_name = h3.get_text(strip=True)
+            # Skip cabinet heading and MP headings (contain em-dash)
+            if ward_name in SKIP_HEADINGS or "–" in ward_name:
+                continue
+
+            accordion = h3.find_next_sibling()
+            if not accordion:
+                continue
+
+            buttons = accordion.select(".kt-blocks-accordion-header")
+            panels = accordion.select(".kt-accordion-panel-inner")
+
+            for button, panel in zip(buttons, panels):
+                if button.get_text(strip=True) != "Councillors":
+                    continue
+
+                for h4 in panel.select("h4"):
+                    heading = h4.get_text(strip=True)
+                    party_match = re.search(r"\(([^)]+)\)\s*$", heading)
+                    if not party_match:
+                        continue
+
+                    party = party_match.group(1)
+                    name_raw = heading[: party_match.start()].strip()
+                    name_raw = re.sub(r"^Cllr\s+", "", name_raw).strip()
+                    if "," in name_raw:
+                        last, first = name_raw.split(",", 1)
+                        name = f"{first.strip()} {last.strip()}"
+                    else:
+                        name = name_raw
+
+                    identifier = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+                    url = f"{self.base_url}#{identifier}"
+
+                    data = {
+                        "url": url,
+                        "identifier": identifier,
+                        "name": name,
+                        "party": party,
+                        "ward": ward_name,
+                    }
+
+                    next_div = h4.find_next_sibling()
+                    if next_div:
+                        cf = next_div.select_one("a[href*='email-protection']")
+                        if cf and "#" in cf["href"]:
+                            hexstr = cf["href"].split("#", 1)[-1]
+                            data["email"] = decode_cfemail(hexstr)
+
+                    prev_fig = h4.find_previous_sibling("figure")
+                    if prev_fig:
+                        img = prev_fig.select_one("img")
+                        src = img.get("src", "") if img else ""
+                        if src and not src.startswith("data:"):
+                            data["photo_url"] = src
+
+                    results.append(data)
+
+        return results
+
+    def get_single_councillor(self, councillor_data):
+        councillor = self.add_councillor(
+            councillor_data["url"],
+            identifier=councillor_data["identifier"],
+            name=councillor_data["name"],
+            party=councillor_data["party"],
+            division=councillor_data["ward"],
+        )
+        if "email" in councillor_data:
+            councillor.email = councillor_data["email"]
+        if "photo_url" in councillor_data:
+            councillor.photo_url = councillor_data["photo_url"]
         return councillor

--- a/scrapers/NEL-north-east-lincolnshire/metadata.json
+++ b/scrapers/NEL-north-east-lincolnshire/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "https://www.nelincs.gov.uk/your-council/councillors-mps-and-meps/find-your-councillor/councillors-by-party/",
+            "base_url": "https://www.nelincs.gov.uk/your-council/councillors-and-mps/",
             "cms_type": "Custom HTML"
         }
     }


### PR DESCRIPTION
## Summary

- Old URL (`councillors-mps-and-meps/find-your-councillor/councillors-by-party/`) returns 404
- NELC moved councillor data to a single page (`councillors-and-mps/`) with all 16 wards in Kadence accordion blocks — no individual councillor profile pages
- Completely rewritten as a single-page scraper: walks ward `<h3>` headings → finds matching accordion "Councillors" pane → extracts name/party from `<h4>` text, email via Cloudflare XOR decode, photo from preceding `<figure>`
- Updated `base_url` in `metadata.json`

## Test plan

- [x] 42 councillors found
- [x] 40/42 with email (2 councillors have no published email)
- [x] 42/42 with photo
- [x] Names clean (Firstname Lastname, no "Cllr" prefix)
- [x] Parties correct

Fixes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)