### PR TITLE
Fix HAR (Harlow) scraper

### DIFF
--- a/scrapers/HAR-harlow/councillors.py
+++ b/scrapers/HAR-harlow/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False


### PR DESCRIPTION
## What broke

wreq's BoringSSL trust store does not include the CA that issued the certificate for `harlow.moderngov.co.uk`, causing `CERTIFICATE_VERIFY_FAILED` on every scrape run. The Harlow ModernGov instance itself is healthy and returns valid councillor data once the cert check is bypassed.

## What was fixed

- `councillors.py`: added `verify_requests = False` to the `Scraper` class

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 33 |
| With email address | 32 |
| With photo | 33 |

---
🤖 Automated fix — 2026-06-02

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9C2NXaNhEQr268L8y8NGR)_