### PR TITLE
Fix NEL (North East Lincolnshire) scraper

### DIFF
--- a/scrapers/NEL-north-east-lincolnshire/councillors.py
+++ b/scrapers/NEL-north-east-lincolnshire/councillors.py
@@ -6,6 +6,7 @@ from lgsf.councillors.scrapers import HTMLCouncillorScraper
 
 
 class Scraper(HTMLCouncillorScraper):
+    verify_requests = False
     list_page = {
         "container_css_selector": "main .col-12 .page-content:nth-child(1)",
         "councillor_css_selector": "li",


### PR DESCRIPTION
## What broke

wreq's BoringSSL trust store does not include the CA that issued the certificate for `www.nelincs.gov.uk`, causing `CERTIFICATE_VERIFY_FAILED` on every scrape run. The council's councillors page is live and returns valid data once the cert check is bypassed.

## What was fixed

- `councillors.py`: added `verify_requests = False` to the `Scraper` class

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 42 |
| With email address | 40 |
| With photo | 42 |

---
🤖 Automated fix — 2026-06-02

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9C2NXaNhEQr268L8y8NGR)_