### PR TITLE
Fix WOC (Worcester): update ModGov base_url to HTTPS

### DIFF
--- a/scrapers/WOC-worcester/councillors.py
+++ b/scrapers/WOC-worcester/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    http_lib = "requests"
+    pass

--- a/scrapers/WOC-worcester/metadata.json
+++ b/scrapers/WOC-worcester/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://committee.worcester.gov.uk",
+            "base_url": "https://committee.worcester.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## Summary

- Updated `base_url` from `http://committee.worcester.gov.uk` to `https://committee.worcester.gov.uk`
- Removed `http_lib = "requests"` override — the default wreq library works fine over HTTPS

The connection-reset errors were caused by `requests` handling the HTTP→HTTPS redirect. Pointing directly at the HTTPS endpoint avoids the redirect entirely.

Verified: 35 councillors scraped with correct name, ward, party, email, and photo.

Fixes #300

## Test plan
- [x] `uv run manage.py councillors --council WOC -v` — 35 councillors, no errors
- [x] `uv run manage.py councillors --council WOC --report` — data looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)