### PR TITLE
Fix HEF (Herefordshire): update ModGov base_url to HTTPS

### DIFF
--- a/scrapers/HEF-herefordshire/metadata.json
+++ b/scrapers/HEF-herefordshire/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://councillors.herefordshire.gov.uk",
+            "base_url": "https://councillors.herefordshire.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## Summary

- Updated `base_url` from `http://councillors.herefordshire.gov.uk` to `https://councillors.herefordshire.gov.uk`

The scraper was making an unnecessary HTTP→HTTPS redirect on every run. Pointing directly at HTTPS avoids this and prevents connection failures under the same conditions that triggered #302.

Verified: 53 councillors scraped with no errors.

Fixes #302

## Test plan
- [x] `uv run manage.py councillors --council HEF -v` — 53 councillors, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)