### PR TITLE
Fix CHR (Cherwell): update ModGov base_url to HTTPS

### DIFF
--- a/scrapers/CHR-cherwell/metadata.json
+++ b/scrapers/CHR-cherwell/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://modgov.cherwell.gov.uk",
+            "base_url": "https://modgov.cherwell.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## Summary

- Updated `base_url` from `http://modgov.cherwell.gov.uk` to `https://modgov.cherwell.gov.uk`

Pointing directly at HTTPS avoids the HTTP→HTTPS redirect and eliminates the connection failures seen in #309.

Verified: 48 councillors scraped with no errors.

Fixes #309

## Test plan
- [x] `uv run manage.py councillors --council CHR -v` — 48 councillors, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)