### PR TITLE
Fix LAC (Lancaster): update ModGov base_url to HTTPS

### DIFF
--- a/scrapers/LAC-lancaster/metadata.json
+++ b/scrapers/LAC-lancaster/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://committeeadmin.lancaster.gov.uk",
+            "base_url": "https://committeeadmin.lancaster.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## Summary

- Updated `base_url` from `http://committeeadmin.lancaster.gov.uk` to `https://committeeadmin.lancaster.gov.uk`

Pointing directly at HTTPS avoids the HTTP→HTTPS redirect and eliminates the timeout/error-page failures seen in #311. The existing `verify_requests = False` is kept as-is.

Verified: 60 councillors scraped with no errors.

Fixes #311

## Test plan
- [x] `uv run manage.py councillors --council LAC -v` — 60 councillors, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)