### PR TITLE
Fix ABC (Armagh City, Banbridge and Craigavon) scraper

### DIFF
--- a/scrapers/ABC-armagh-city-banbridge-and-craigavon/councillors.py
+++ b/scrapers/ABC-armagh-city-banbridge-and-craigavon/councillors.py
@@ -46,6 +46,7 @@ class Scraper(PagedHTMLCouncillorScraper):
         )
         councillor.email = email
 
-        councillor.photo_url = councillor_html.select_one("img")["src"]
-        councillor.photo_url = councillor.photo_url.replace("120x150", "240x300")
+        with contextlib.suppress(TypeError):
+            councillor.photo_url = councillor_html.select_one("img")["src"]
+            councillor.photo_url = councillor.photo_url.replace("120x150", "240x300")
         return councillor


### PR DESCRIPTION
## What broke

The scraper crashes with `TypeError: 'NoneType' object is not subscriptable` when a councillor card on the listing page has no `<img>` element. The photo URL extraction code (`councillor_html.select_one("img")["src"]`) subscripts the `None` return value from `select_one`. At least one currently-listed councillor has no photo published on the site.

## What was fixed

- Wrapped the photo URL assignment in `contextlib.suppress(TypeError)` so councillors without a photo are scraped normally with `photo_url` left unset, matching the pattern used in other scrapers in this codebase.

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 41 |
| With email address | 41 |
| With photo | 40 |

One councillor currently has no photo on the council's website; they will be scraped without a photo URL until the council publishes one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01STnnEBsGHQbDEjx2EVKqtt)_