### PR TITLE
Fix FEN (Fenland) scraper

### DIFF
--- a/scrapers/FEN-fenland/councillors.py
+++ b/scrapers/FEN-fenland/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False


### PR DESCRIPTION
## What broke

The ModGov endpoint at `www.fenland.gov.uk` uses a TLS certificate that is rejected by wreq's bundled BoringSSL trust store, producing `CERTIFICATE_VERIFY_FAILED` on every request. The scraper aborts before returning any data.

## What was fixed

- Added `verify_requests = False` to the `Scraper` class, bypassing wreq's certificate verification. The site serves read-only public councillor data so the risk is acceptable.

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 43 |
| With email address | 43 |
| With photo | 43 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01STnnEBsGHQbDEjx2EVKqtt)_