### PR TITLE
Fix BNH (Brighton and Hove) scraper

### DIFF
--- a/scrapers/BNH-brighton-and-hove/councillors.py
+++ b/scrapers/BNH-brighton-and-hove/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False

--- a/scrapers/BNH-brighton-and-hove/metadata.json
+++ b/scrapers/BNH-brighton-and-hove/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://present.brighton-hove.gov.uk",
+            "base_url": "https://democracy.brighton-hove.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## What broke

The Brighton and Hove democracy portal has migrated from `http://present.brighton-hove.gov.uk` to a new hostname `https://democracy.brighton-hove.gov.uk`. Requests to the old URL were redirected, causing a 30-second request timeout. The new hostname also has a TLS certificate that fails wreq's strict verification (the CA is valid per the system trust store but not trusted by wreq's BoringSSL bundle), causing a `CERTIFICATE_VERIFY_FAILED` error.

## What was fixed

- Updated `base_url` in `metadata.json` from `http://present.brighton-hove.gov.uk` to `https://democracy.brighton-hove.gov.uk`
- Added `verify_requests = False` to bypass the certificate verification failure on the new hostname

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 54 |
| With email address | 53 |
| With photo | 54 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01PryUVRYRDSwSZQpUeWoLPe)_