### PR TITLE
Fix SRY (Surrey County Council) scraper

### DIFF
--- a/scrapers/SRY-surrey/councillors.py
+++ b/scrapers/SRY-surrey/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    http_lib = "playwright"

--- a/scrapers/SRY-surrey/metadata.json
+++ b/scrapers/SRY-surrey/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "https://mycouncil.surreycc.gov.uk/",
+            "base_url": "https://mycouncil.surreycc.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## What broke

Surrey's ModGov endpoint (`mycouncil.surreycc.gov.uk`) is behind Incapsula WAF protection. Plain wreq requests return a 212-byte Incapsula JS-challenge HTML stub instead of the councillor XML, resulting in 0 councillors scraped (the scraper ran without error but got no data). Additionally, the `base_url` in `metadata.json` had a trailing slash that produced a double-slash in the constructed API URL (`https://mycouncil.surreycc.gov.uk//mgWebService.asmx/GetCouncillorsByWard`).

## What was fixed

- Added `http_lib = "playwright"` to the Scraper class — headless Chromium executes the Incapsula JS challenge, sets the required cookies, and triggers a redirect to the actual XML endpoint. Chrome's XML viewer embeds the raw XML elements in the page DOM, so BeautifulSoup's xml parser successfully finds all ward/councillor elements.
- Removed trailing slash from `base_url` in `metadata.json`

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 81 |
| With email address | 79 |
| With photo | 81 |

> Note: Local verification used `ignore_https_errors=True` in playwright because the locally-downloaded chromium-headless-shell has a restricted CA bundle that does not trust `mycouncil.surreycc.gov.uk`'s certificate. The Lambda container image ships with a system-linked Chromium where this cert is trusted, matching the behaviour seen in COT (PR #334). The councillor data above was confirmed via direct playwright scraping with cert errors bypassed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhvVTEdWNbYs29fTgmcc9A)_