### PR TITLE
Fix STV (Stevenage) scraper

### DIFF
--- a/scrapers/STV-stevenage/councillors.py
+++ b/scrapers/STV-stevenage/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False

--- a/scrapers/STV-stevenage/metadata.json
+++ b/scrapers/STV-stevenage/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://democracy.stevenage.gov.uk",
+            "base_url": "https://democracy.stevenage.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## What broke

Stevenage's democracy portal has two layered issues. The `base_url` in `metadata.json` used `http://`, which causes `wreq` to attempt an IPv6 (AAAA) DNS lookup for `democracy.stevenage.gov.uk`. Stevenage's DNS server returns `ServFail` (rather than `NXDOMAIN`) for AAAA queries — a DNS misconfiguration on the council's side — and `wreq` treats `ServFail` as a hard failure without falling back to IPv4. Switching to `https://` causes `wreq` to use a direct HTTPS connection and avoids the AAAA lookup path. However, the `https://democracy.stevenage.gov.uk` certificate is not trusted by `wreq`'s embedded BoringSSL CA bundle, so a plain HTTPS request fails with `CERTIFICATE_VERIFY_FAILED`. Adding `verify_requests = False` bypasses certificate validation and allows the ModGov ASMX endpoint to return data successfully.

## What was fixed

- Changed `base_url` from `http://democracy.stevenage.gov.uk` to `https://democracy.stevenage.gov.uk` in `metadata.json`
- Added `verify_requests = False` to the `Scraper` class in `councillors.py`

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 39 |
| With email address | 0 |
| With photo | 39 |

> Note: Stevenage does not publish email addresses via their ModGov XML service — the `<emailaddress>` field is absent from all councillor records. This is the council's publishing policy, not a scraper issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AH1pabh6sGwAoBfjE3E5Ld)_