### PR TITLE
Fix MON (Monmouthshire) scraper

### DIFF
--- a/scrapers/MON-monmouthshire/councillors.py
+++ b/scrapers/MON-monmouthshire/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False


### PR DESCRIPTION
## What broke

The `https://democracy.monmouthshire.gov.uk` certificate is not trusted by `wreq`'s embedded BoringSSL CA bundle. Every request to the ModGov ASMX endpoint fails immediately with `CERTIFICATE_VERIFY_FAILED`. The dashboard error showed "HTTP 503 Service Unavailable" but local reproduction reveals the underlying cause is a TLS certificate validation failure.

## What was fixed

- Added `verify_requests = False` to the `Scraper` class in `councillors.py`

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 46 |
| With email address | 0 |
| With photo | 46 |

> Note: Monmouthshire does not publish email addresses via their ModGov XML service — the `<emailaddress>` field is absent from all councillor records.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AH1pabh6sGwAoBfjE3E5Ld)_