### PR TITLE
Fix DAC (Dacorum) scraper

### DIFF
--- a/scrapers/DAC-dacorum/councillors.py
+++ b/scrapers/DAC-dacorum/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False


### PR DESCRIPTION
## What broke

The `https://democracy.dacorum.gov.uk` certificate is not trusted by `wreq`'s embedded BoringSSL CA bundle. Every request to the ModGov ASMX endpoint fails immediately with `CERTIFICATE_VERIFY_FAILED`. The dashboard error showed "Request timeout after 30+ seconds" but local reproduction reveals the underlying cause is a TLS certificate validation failure (completes in under 1 second, not a timeout).

## What was fixed

- Added `verify_requests = False` to the `Scraper` class in `councillors.py`

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 50 |
| With email address | 0 |
| With photo | 50 |

> Note: Dacorum does not publish email addresses via their ModGov XML service — the `<emailaddress>` field is absent from all councillor records.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AH1pabh6sGwAoBfjE3E5Ld)_