### PR TITLE
Fix HAL (Halton) scraper

### DIFF
--- a/scrapers/HAL-halton/councillors.py
+++ b/scrapers/HAL-halton/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False

--- a/scrapers/HAL-halton/metadata.json
+++ b/scrapers/HAL-halton/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://councillors.halton.gov.uk",
+            "base_url": "https://councillors.halton.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## What broke

The scraper used `http://councillors.halton.gov.uk` as its base URL. Halton's server now enforces HTTPS-only (HSTS with `max-age=31536000`) and no longer accepts TCP connections on port 80, causing the scraper to time out after 30 seconds. Switching to `https://` restores connectivity, but wreq's embedded BoringSSL CA bundle does not trust Halton's TLS certificate, so `verify_requests = False` is also required.

## What was fixed

- Changed `base_url` from `http://councillors.halton.gov.uk` to `https://councillors.halton.gov.uk` in `metadata.json`
- Added `verify_requests = False` to the `Scraper` class in `councillors.py`

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 53 |
| With email address | 53 |
| With photo | 53 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bc9qGHVfiLHJAuB9DvWfPS)_