### PR TITLE
Fix MDW (Medway) scraper

### DIFF
--- a/scrapers/MDW-medway/councillors.py
+++ b/scrapers/MDW-medway/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False


### PR DESCRIPTION
## What broke

Medway's ModGov server at `https://democracy.medway.gov.uk` has a TLS certificate that is not trusted by wreq's embedded BoringSSL CA bundle. Every request failed immediately with `CERTIFICATE_VERIFY_FAILED`, causing the scraper to report a connection error.

## What was fixed

- Added `verify_requests = False` to the `Scraper` class in `councillors.py`

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 59 |
| With email address | 59 |
| With photo | 59 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01L6y1P9EMAtyN414JhJ2HNV)_