### PR TITLE
Fix RDB (Redbridge) scraper

### DIFF
--- a/scrapers/RDB-redbridge/councillors.py
+++ b/scrapers/RDB-redbridge/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    http_lib = "playwright"

--- a/scrapers/RDB-redbridge/metadata.json
+++ b/scrapers/RDB-redbridge/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://moderngov.redbridge.gov.uk",
+            "base_url": "https://moderngov.redbridge.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## What broke

Redbridge's ModGov server at `http://moderngov.redbridge.gov.uk` no longer responds on port 80 — the server accepts TCP connections but silently drops all HTTP requests (classic Incapsula WAF silent-block behaviour when the request fingerprint doesn't look like a real browser). The same silent-block applies to wreq's requests over HTTPS. This produces the "Request timeout after 30+ seconds" error seen in the dashboard.

## What was fixed

- Changed `base_url` from `http://moderngov.redbridge.gov.uk` to `https://moderngov.redbridge.gov.uk` in `metadata.json`
- Added `http_lib = "playwright"` to the `Scraper` class — headless Chromium presents a genuine browser TLS + HTTP/2 fingerprint, which causes Incapsula to issue (and playwright to automatically solve) the JS challenge, after which the ModGov XML endpoint responds normally

This is the same fix pattern used for SRY (PR #340). On Lambda, the system-linked Chromium trusts the `moderngov.redbridge.gov.uk` certificate so no `verify_requests = False` is needed.

## Scrape results

Local end-to-end verification was not possible: the CI/dev environment's egress proxy IP is silently blocked by Incapsula (the same block that affects wreq). The fix is structurally identical to the working SRY fix and should produce full councillor data on Lambda.

| Metric | Count |
|--------|-------|
| Councillors found | pending Lambda run |
| With email address | pending Lambda run |
| With photo | pending Lambda run |

> Note: Results will be confirmed in a follow-up PR comment once merged and run on Lambda.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nt9BW5nahp5fHGrTaicaoH)_