### PR TITLE
Fix ELS (Na h-Eileanan an Iar) scraper

### DIFF
--- a/scrapers/ELS-na-h-eileanan-an-iar/councillors.py
+++ b/scrapers/ELS-na-h-eileanan-an-iar/councillors.py
@@ -7,7 +7,6 @@ from lgsf.councillors.scrapers import HTMLCouncillorScraper
 
 
 class Scraper(HTMLCouncillorScraper):
-    http_lib = "requests"
     verify_requests = False
     list_page = {
         "container_css_selector": "article",


### PR DESCRIPTION
## What broke

The cne-siar.gov.uk server started returning 403 Forbidden for requests made by the Python `requests` library. The `requests` library has a distinctive TLS fingerprint and User-Agent that the WAF protecting the site now blocks. The scraper had previously been set to `http_lib = "requests"` as a workaround (likely for a certificate or connectivity issue that no longer applies), but this is now the direct cause of failure.

## What was fixed

- Removed `http_lib = "requests"` from the Scraper class, reverting to wreq's default Firefox TLS fingerprint which the server accepts
- `verify_requests = False` is retained as the site certificate is still not trusted by wreq's BoringSSL CA bundle

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 29 |
| With email address | 29 |
| With photo | 28 |

> Note: One councillor (Norman Macdonald) appears to have no photo published on their individual profile page — confirmed by inspecting the page directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5iPhKDaUgtpME3XUozxG1)_