### PR TITLE
Fix NET (Newcastle upon Tyne) scraper

### DIFF
--- a/scrapers/NET-newcastle-upon-tyne/councillors.py
+++ b/scrapers/NET-newcastle-upon-tyne/councillors.py
@@ -2,4 +2,5 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False
+    http_lib = "playwright"

--- a/scrapers/NET-newcastle-upon-tyne/metadata.json
+++ b/scrapers/NET-newcastle-upon-tyne/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://democracy.newcastle.gov.uk",
+            "base_url": "https://democracy.newcastle.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## What broke

Newcastle's ModGov server at `http://democracy.newcastle.gov.uk` HTTP-307-redirects to `https://democracy.newcastle.gov.uk`. After following the redirect, wreq fails immediately with `CERTIFICATE_VERIFY_FAILED` because the council's TLS certificate is not trusted by wreq's embedded BoringSSL CA bundle. Even after adding `verify_requests = False` (which bypasses cert checking), wreq requests to the HTTPS endpoint time out after 30 seconds — the classic Incapsula WAF silent-drop pattern where the server accepts TCP connections but never sends an HTTP response to non-browser clients.

## What was fixed

- Changed `base_url` from `http://democracy.newcastle.gov.uk` to `https://democracy.newcastle.gov.uk` in `metadata.json`
- Added `verify_requests = False` to the `Scraper` class (bypasses BoringSSL cert check in case the wreq path is ever used)
- Added `http_lib = "playwright"` to the `Scraper` class — headless Chromium presents a genuine browser TLS fingerprint, which causes Incapsula to issue (and playwright to automatically solve) the JS challenge, after which the ModGov XML endpoint responds normally

This is the same fix pattern that resolved the identical failure for Redbridge (PR #354).

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | pending Lambda run |
| With email address | pending Lambda run |
| With photo | pending Lambda run |

> Note: Local end-to-end verification was not possible because this dev environment routes outbound TLS through an Anthropic egress proxy that substitutes its own certificate, causing the locally-downloaded chromium-headless-shell to fail with `ERR_CERT_AUTHORITY_INVALID`. The fix is structurally identical to the working Redbridge fix (PR #354) — results will be confirmed in a follow-up comment once merged and run on Lambda.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wCXfuWFgB28kaSzExU1kH)_