### PR TITLE
Fix BPC (Bournemouth, Christchurch and Poole) scraper

### DIFF
--- a/scrapers/BPC-bournemouth-christchurch-and-poole/councillors.py
+++ b/scrapers/BPC-bournemouth-christchurch-and-poole/councillors.py
@@ -2,4 +2,4 @@ from lgsf.councillors.scrapers import ModGovCouncillorScraper
 
 
 class Scraper(ModGovCouncillorScraper):
-    pass
+    verify_requests = False

--- a/scrapers/BPC-bournemouth-christchurch-and-poole/metadata.json
+++ b/scrapers/BPC-bournemouth-christchurch-and-poole/metadata.json
@@ -14,7 +14,7 @@
     },
     "services": {
         "councillors": {
-            "base_url": "http://democracy.bcpcouncil.gov.uk",
+            "base_url": "https://democracy.bcpcouncil.gov.uk",
             "cms_type": "ModernGov"
         }
     }


### PR DESCRIPTION
## What broke

BCP Council's ModGov server redirects `http://democracy.bcpcouncil.gov.uk` to `https://`, but the HTTPS certificate isn't trusted by `wreq`'s embedded BoringSSL CA bundle. Every request to the ASMX endpoint failed with `CERTIFICATE_VERIFY_FAILED`, even after following the HTTPS redirect.

## What was fixed

- Changed `base_url` from `http://democracy.bcpcouncil.gov.uk` to `https://democracy.bcpcouncil.gov.uk` in `metadata.json`
- Added `verify_requests = False` to the `Scraper` class in `councillors.py`

## Scrape results

| Metric | Count |
|--------|-------|
| Councillors found | 76 |
| With email address | 76 |
| With photo | 76 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsmXsntfyfWWwW7wcdL99H)_